### PR TITLE
Update Copy plugin in rollup.config.js

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,8 +4,6 @@ import commonjs from '@rollup/plugin-commonjs';
 import livereload from 'rollup-plugin-livereload';
 import { terser } from 'rollup-plugin-terser';
 import copy from 'rollup-plugin-copy'
-import del from 'del'
-
 
 
 const staticDir = 'static'
@@ -15,8 +13,6 @@ const production = !process.env.ROLLUP_WATCH;
 const bundling = process.env.BUNDLING || production ? 'dynamic' : 'bundle'
 const shouldPrerender = (typeof process.env.PRERENDER !== 'undefined') ? process.env.PRERENDER : !!production
 
-
-del.sync(distDir + '/**')
 
 function createConfig({ output, inlineDynamicImports, plugins = [] }) {
   const transform = inlineDynamicImports ? bundledTransform : dynamicTransform
@@ -32,7 +28,7 @@ function createConfig({ output, inlineDynamicImports, plugins = [] }) {
     plugins: [
       copy({
         targets: [
-          { src: staticDir + '/**/!(__index.html)', dest: distDir },
+          { src: [staticDir + "/*", "!*/(__index.html)"], dest: distDir },
           { src: `${staticDir}/__index.html`, dest: distDir, rename: '__app.html', transform },
         ],
 	copyOnce: true,


### PR DESCRIPTION
Current copy command copies static folder recursively. If you have a large number of static assets multiple levels deep, everything will be copied twice (once to /dist/* and once to /dist/correctfolder/*.  If you have hundreds or thousands of files in static, this might impact build time. Just copying the static dir with /* instead of /** appears to fix this issue.  It also remove the additional step of `del.sync(distDir + '/**')` and the del import.